### PR TITLE
Unimported metadata

### DIFF
--- a/convert_gvf_to_vcf/convertGVFtoVCF.py
+++ b/convert_gvf_to_vcf/convertGVFtoVCF.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-from collections import Counter
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
 from convert_gvf_to_vcf.conversionstatistics import FileStatistics
@@ -8,7 +7,6 @@ from convert_gvf_to_vcf.gather_metadata import gather_metadata
 from convert_gvf_to_vcf.lookup import Lookup
 from convert_gvf_to_vcf.utils import read_in_gvf_header, read_in_gvf_data
 from convert_gvf_to_vcf.vcfline import VcfLineBuilder
-from convert_gvf_to_vcf.metadataJSON import DGVaMetadataRetriever
 
 logger = log_cfg.get_logger(__name__)
 

--- a/convert_gvf_to_vcf/gather_metadata.py
+++ b/convert_gvf_to_vcf/gather_metadata.py
@@ -1,26 +1,30 @@
 import argparse
 
-from convert_gvf_to_vcf.metadata_retrievers.evametadataJSON import EVAMetadataRetriever
+from convert_gvf_to_vcf.metadata_retrievers.dgvametadata import DGVAMetadataRetriever
+from convert_gvf_to_vcf.metadata_retrievers.evametadata import EVAMetadataRetriever
 
 
-def gather_metadata(config_input, json_output, study_accession, vcf_output, assembly, assembly_report):
+def gather_metadata(config_input, json_output_eva, json_output_dgva, study_accession, vcf_output, assembly, assembly_report):
 
-    retrieved_dgva_metadata = EVAMetadataRetriever(config_input)
+    retrieved_eva_metadata = EVAMetadataRetriever(config_input)
+    with retrieved_eva_metadata:
+        retrieved_eva_metadata.create_json_eva(json_file_path=json_output_eva, study_accession=study_accession, vcf_output=vcf_output, assembly=assembly, assembly_report=assembly_report)
+    retrieved_dgva_metadata = DGVAMetadataRetriever(config_input)
     with retrieved_dgva_metadata:
-        retrieved_dgva_metadata.create_json_file(json_file_path=json_output, study_accession=study_accession, vcf_output=vcf_output, assembly=assembly, assembly_report=assembly_report)
-
+        retrieved_dgva_metadata.create_json_dgva(json_output_dgva, study_accession)
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--config")
-    parser.add_argument("--json_output")
+    parser.add_argument("--json_output_eva")
+    parser.add_argument("--json_output_dgva")
     parser.add_argument("--study_accession")
     parser.add_argument("--vcf_output")
     parser.add_argument("--assembly")
     parser.add_argument("--assembly_report")
     args = parser.parse_args()
 
-    gather_metadata(args.config, args.json_output, args.study_accession, args.vcf_output, args.assembly, args.assembly_report)
+    gather_metadata(args.config, args.json_output_eva, args.json_output_dgva, args.study_accession, args.vcf_output, args.assembly, args.assembly_report)
 
 if __name__ == "__main__":
     main()

--- a/convert_gvf_to_vcf/gather_metadata.py
+++ b/convert_gvf_to_vcf/gather_metadata.py
@@ -1,11 +1,11 @@
 import argparse
 
-from convert_gvf_to_vcf.metadataJSON import DGVaMetadataRetriever
+from convert_gvf_to_vcf.metadata_retrievers.evametadataJSON import EVAMetadataRetriever
 
 
 def gather_metadata(config_input, json_output, study_accession, vcf_output, assembly, assembly_report):
 
-    retrieved_dgva_metadata = DGVaMetadataRetriever(config_input)
+    retrieved_dgva_metadata = EVAMetadataRetriever(config_input)
     with retrieved_dgva_metadata:
         retrieved_dgva_metadata.create_json_file(json_file_path=json_output, study_accession=study_accession, vcf_output=vcf_output, assembly=assembly, assembly_report=assembly_report)
 

--- a/convert_gvf_to_vcf/metadata_retrievers/basemetadataretriever.py
+++ b/convert_gvf_to_vcf/metadata_retrievers/basemetadataretriever.py
@@ -1,0 +1,130 @@
+from abc import ABC, abstractmethod
+
+import oracledb
+from ebi_eva_common_pyutils.config import cfg
+from ebi_eva_common_pyutils.logger import logging_config as log_cfg
+
+logger = log_cfg.get_logger(__name__)
+class BaseMetadataRetriever(ABC):
+    """ The responsibility of this base class is to ensure a consistent method for metadata retrieval.
+    This includes database connection and the ingestion and validation of data.
+    """
+    def __init__(self, path_to_config_yaml):
+        # coming from the config file
+        cfg.load_config_file(path_to_config_yaml)  # cfg is a dictionary
+        # db connection setup
+        self._connection = None
+        self._host = self._get_validated_value(cfg, ("DGVA","host"), str, default_value=None) # get information from the config dictionary
+        self._port = self._get_validated_value(cfg, ("DGVA", "port"), str, default_value=None)
+        self._username = self._get_validated_value(cfg, ("DGVA", "user"), str, default_value=None)
+        self._password = self._get_validated_value(cfg, ("DGVA", "password"), str, default_value=None)
+        self._service_name = self._get_validated_value(cfg, ("DGVA", "service_name"), str, default_value=None)
+        # db parameters
+        self._max_retries = 3
+
+    def __enter__(self):
+        # enables the "with" context manager
+        _ = self.connection
+        logger.info("Opening connection using a context manager - SUCCESS")
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # closes the connection and resets the state of connection
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+            logger.info("Closing connection safely using a context manager - SUCCESS")
+
+    @staticmethod
+    def _get_validated_value(config, key_parts_to_get, expected_type, default_value=None):
+        # key_parts_to_get is a tuple of multiple values so unpacking
+        value_in_config = config.query(*key_parts_to_get, ret_default=default_value)
+        if value_in_config is None:
+            raise ValueError(f"Missing key required: {key_parts_to_get}")
+        if not isinstance(value_in_config, expected_type):
+            try:
+                # cast the value to its expected type
+                value_in_config = expected_type(value_in_config)
+            except (ValueError, TypeError):
+                raise TypeError(f"Key '{key_parts_to_get}' must be {expected_type.__name__}")
+        return value_in_config
+
+    @property
+    def connection(self):
+        attempts = 0
+        while attempts < self._max_retries:
+            # if there is a healthy connection established, return it
+            if self._connection is not None and self._connection.is_healthy():
+                logger.info("A healthy connection has already been established.")
+                return self._connection
+            # if there is an unhealthy connection, close it and reset the state
+            if self._connection:
+                logger.warning("Unhealthy connection. Attempting to reconnect.")
+                try:
+                    # close the unhealthy connection
+                    self._connection.close()
+                    logger.info("Connection closed safely.")
+                except:
+                    pass
+                self._connection = None
+            # first connection or reconnection
+            attempts += 1
+            try:
+                logger.info("Connecting to the database.")
+                self._connection = oracledb.connect(host=self._host, port=self._port,
+                                                    user=self._username, password=self._password, service_name=self._service_name)
+                return self._connection
+            except Exception as e:
+                logger.error(f"Failed to connect. {e}")
+                if attempts >= self._max_retries:
+                    logger.error(f"Max connection retries reached: {self._max_retries}.")
+                    raise
+
+    def load_from_db(self, query_to_load):
+        """ Searches the DGVa database using the query provided.
+        :param query_to_load : SQL query
+        :return: a list of rows (or if query returns nothing an empty list)
+        """
+        try:
+            # create the iterator to process queries
+            with self.connection.cursor() as cur:
+                # prepare to fetch data
+                ###############################################################################
+                # WARNING: do not use f-strings or % formatting here, use placeholders instead
+                query = query_to_load
+                # query_placeholders = query_place_holder_to_load
+                # cur.execute(query, query_placeholders)
+                ###############################################################################
+                # run the sql query
+                logger.info(f"Executing the following query: {query}")
+                cur.execute(query)
+                # fetch the data from the cursor
+                rows = cur.fetchall() # returns list of tuples
+                logger.info(f"Fetching the data: {rows}")
+                logger.info(f"Fetching metadata query - SUCCESS - {len(rows)} records found")
+                return rows
+        except Exception as e:
+            logger.warning(f"Database error: {e}")
+            return []
+
+    def validate_fetch_result(self, eva_field_name, fetch_result_list, single_value_as_str):
+        try:
+            if fetch_result_list:
+                results = [row[0] for row in fetch_result_list if row]
+                if single_value_as_str:
+                    fetch_result = results[0] if len(results) == 1 else results
+                else:
+                    fetch_result = results
+                if fetch_result:
+                    # SUCCESS if value is present or None
+                    logger.info(f"Fetching {eva_field_name} - SUCCESS - Value(s) for {eva_field_name} found: {fetch_result}.")
+            else:
+                raise ValueError(f"Missing data: {eva_field_name}.")
+        except ValueError as e:
+            logger.error(f"Fetching {eva_field_name}  - FAILURE - {eva_field_name} not found. {e} Setting value as empty string.")
+            fetch_result = ""
+        return fetch_result
+
+    @abstractmethod
+    def retrieve(self):
+        pass

--- a/convert_gvf_to_vcf/metadata_retrievers/dgvametadata.py
+++ b/convert_gvf_to_vcf/metadata_retrievers/dgvametadata.py
@@ -1,0 +1,109 @@
+import json
+import os
+import re
+from datetime import datetime
+
+from pypika import Query, Table, Schema
+
+from ebi_eva_common_pyutils.logger import logging_config as log_cfg
+
+logger = log_cfg.get_logger(__name__)
+
+from convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever import BaseMetadataRetriever
+class DGVAMetadataRetriever(BaseMetadataRetriever):
+    def retrieve(self):
+        pass
+
+    def create_json_dgva(self, json_file_path, study_accession):
+        json_in_dgva_format = {
+            "dgva": [
+                {
+                    "creationDate": self._fetch_creation_date(),
+                    "studyComment": self._get_study_comment(),
+                    "commentUserName": self._get_comment_user_name(),
+                    "commentTimestamp": self._get_comment_timestamp(),
+                    "submissionVersion": self._get_submission_version(),
+                    "updateComment": self._get_update_comment(),
+                    "newFeature": self._get_new_feature(),
+                    "correction": self._get_correction(),
+                    "affiliationUrl": self._get_affiliation_url(),
+                    "experimentSite": self._get_experiment_site(),
+                    "experimentResolution": self._get_experiment_resolution(),
+                    "detectionMethod": self._get_detection_method(),
+                    "detectionDescription": self._get_detection_description(),
+                    "curatorName": self._get_curator_name(),
+                    "curatorEmail": self._get_curator_email(),
+                    "curatedSetName": self._get_curated_set_name(),
+                    "curatedSetLink": self._get_curated_set_link(),
+                    "methodType": self._get_method_type()
+                }
+            ]
+        }
+        with open(json_file_path, 'w') as f:
+            json.dump(json_in_dgva_format, f, indent=4)
+        logger.info(f"Write DGVA JSON file for {study_accession}- SUCCESS: {json_file_path}")
+
+    def _fetch_creation_date(self, study_accession):
+        # create the schema objects
+        db = Schema("DGVA")
+        # create the table objects
+        ds = Table("DGVA_STUDY", schema=db).as_("ds")
+        project_title_query = (
+            Query.from_(ds)
+            .select(ds.CREATION_DATE)
+            .where(ds.STUDY_ACCESSION == study_accession)
+        )
+        creation_date_list = self.load_from_db(project_title_query.get_sql(quote_char=None))
+        [creation_date, *_] = self.validate_fetch_result("creationDate", creation_date_list) or [""]
+        return creation_date
+
+    def _get_study_comment(self):
+        pass
+
+    def _get_comment_user_name(self):
+        pass
+
+    def _get_comment_timestamp(self):
+        pass
+
+    def _get_submission_version(self):
+        pass
+
+    def _get_update_comment(self):
+        pass
+
+    def _get_new_feature(self):
+        pass
+
+    def _get_method_type(self):
+        pass
+
+    def _get_curated_set_link(self):
+        pass
+
+    def _get_curated_set_name(self):
+        pass
+
+    def _get_curator_email(self):
+        pass
+
+    def _get_curator_name(self):
+        pass
+
+    def _get_detection_description(self):
+        pass
+
+    def _get_detection_method(self):
+        pass
+
+    def _get_experiment_resolution(self):
+        pass
+
+    def _get_experiment_site(self):
+        pass
+
+    def _get_affiliation_url(self):
+        pass
+
+    def _get_correction(self):
+        pass

--- a/convert_gvf_to_vcf/metadata_retrievers/evametadata.py
+++ b/convert_gvf_to_vcf/metadata_retrievers/evametadata.py
@@ -23,13 +23,8 @@ class EVAMetadataRetriever(BaseMetadataRetriever):
     def retrieve(self):
         pass
 
-    def create_json_file(self, json_file_path, study_accession, vcf_output, assembly, assembly_report):
+    def create_json_eva(self, json_file_path, study_accession, vcf_output, assembly, assembly_report):
         project_metadata = self._get_project_new(study_accession)  # (all projects are new projects)
-
-        # determine if sample new or pre-registered
-        # list of tuples [(is_sample_preregistered, biosample_accession)]
-
-        # sample_ids = self._fetch_sample_id_list(study_accession)
         sample_registration_statuses = self._determine_sample_pre_registered(study_accession)
         sample_metadata_array = []
 

--- a/convert_gvf_to_vcf/metadata_retrievers/evametadataJSON.py
+++ b/convert_gvf_to_vcf/metadata_retrievers/evametadataJSON.py
@@ -5,16 +5,14 @@ import re
 from datetime import datetime
 from collections import namedtuple
 
-import oracledb
 from pypika import Query, Table, Schema
 
-from ebi_eva_common_pyutils.config import cfg
 from ebi_eva_common_pyutils.logger import logging_config as log_cfg
 
 logger = log_cfg.get_logger(__name__)
 
-
-class DGVaMetadataRetriever:
+from convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever import BaseMetadataRetriever
+class EVAMetadataRetriever(BaseMetadataRetriever):
     """
     The responsibility of this class is to retrieve the metadata for submission to EVA.
     It will extract the required properties to fill in the EVA JSON submission schema
@@ -22,88 +20,8 @@ class DGVaMetadataRetriever:
     by querying the DGVa database.
     It will generate the metadata submission JSON file.
     """
-    def __init__(self, path_to_config_yaml):
-        # coming from the config file
-        cfg.load_config_file(path_to_config_yaml)  # cfg is a dictionary
-        # db connection setup
-        self._connection = None
-        self._host = self._get_validated_value(cfg, ("DGVA","host"), str, default_value=None) # get information from the config dictionary
-        self._port = self._get_validated_value(cfg, ("DGVA", "port"), str, default_value=None)
-        self._username = self._get_validated_value(cfg, ("DGVA", "user"), str, default_value=None)
-        self._password = self._get_validated_value(cfg, ("DGVA", "password"), str, default_value=None)
-        self._service_name = self._get_validated_value(cfg, ("DGVA", "service_name"), str, default_value=None)
-        # db parameters
-        self._max_retries = 3
-    def __enter__(self):
-        # enables the "with" context manager
-        _ = self.connection
-        logger.info("Opening connection using a context manager - SUCCESS")
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        # closes the connection and resets the state of connection
-        if self._connection:
-            self._connection.close()
-            self._connection = None
-            logger.info("Closing connection safely using a context manager - SUCCESS")
-
-    @property
-    def connection(self):
-        attempts = 0
-        while attempts < self._max_retries:
-            # if there is a healthy connection established, return it
-            if self._connection is not None and self._connection.is_healthy():
-                logger.info("A healthy connection has already been established.")
-                return self._connection
-            # if there is an unhealthy connection, close it and reset the state
-            if self._connection:
-                logger.warning("Unhealthy connection. Attempting to reconnect.")
-                try:
-                    # close the unhealthy connection
-                    self._connection.close()
-                    logger.info("Connection closed safely.")
-                except:
-                    pass
-                self._connection = None
-            # first connection or reconnection
-            attempts += 1
-            try:
-                logger.info("Connecting to the database.")
-                self._connection = oracledb.connect(host=self._host, port=self._port,
-                                                    user=self._username, password=self._password, service_name=self._service_name)
-                return self._connection
-            except Exception as e:
-                logger.error(f"Failed to connect. {e}")
-                if attempts >= self._max_retries:
-                    logger.error(f"Max connection retries reached: {self._max_retries}.")
-                    raise
-
-    def load_from_db(self, query_to_load):
-        """ Searches the DGVa database using the query provided.
-        :param query_to_load : SQL query
-        :return: a list of rows (or if query returns nothing an empty list)
-        """
-        try:
-            # create the iterator to process queries
-            with self.connection.cursor() as cur:
-                # prepare to fetch data
-                ###############################################################################
-                # WARNING: do not use f-strings or % formatting here, use placeholders instead
-                query = query_to_load
-                # query_placeholders = query_place_holder_to_load
-                # cur.execute(query, query_placeholders)
-                ###############################################################################
-                # run the sql query
-                logger.info(f"Executing the following query: {query}")
-                cur.execute(query)
-                # fetch the data from the cursor
-                rows = cur.fetchall() # returns list of tuples
-                logger.info(f"Fetching the data: {rows}")
-                logger.info(f"Fetching metadata query - SUCCESS - {len(rows)} records found")
-                return rows
-        except Exception as e:
-            logger.warning(f"Database error: {e}")
-            return []
+    def retrieve(self):
+        pass
 
     def create_json_file(self, json_file_path, study_accession, vcf_output, assembly, assembly_report):
         project_metadata = self._get_project_new(study_accession)  # (all projects are new projects)
@@ -133,20 +51,6 @@ class DGVaMetadataRetriever:
         with open(json_file_path, 'w') as f:
             json.dump(json_in_eva_format, f, indent=4)
         logger.info(f"Write JSON file for {study_accession}- SUCCESS: {json_file_path}")
-
-    @staticmethod
-    def _get_validated_value(config, key_parts_to_get, expected_type, default_value=None):
-        # key_parts_to_get is a tuple of multiple values so unpacking
-        value_in_config = config.query(*key_parts_to_get, ret_default=default_value)
-        if value_in_config is None:
-            raise ValueError(f"Missing key required: {key_parts_to_get}")
-        if not isinstance(value_in_config, expected_type):
-            try:
-                # cast the value to its expected type
-                value_in_config = expected_type(value_in_config)
-            except (ValueError, TypeError):
-                raise TypeError(f"Key '{key_parts_to_get}' must be {expected_type.__name__}")
-        return value_in_config
 
     # THESE GETTERS GET THE RELEVANT JSON OBJECT FOR THE SECTION
     def _get_submitter_details(self, study_accession):
@@ -496,23 +400,6 @@ class DGVaMetadataRetriever:
                 pubmed_publications.append(pubmed_string)
         return project_hold_date, project_links, project_parent_project, pubmed_publications
     # VALIDATING
-    def validate_fetch_result(self, eva_field_name, fetch_result_list, single_value_as_str):
-        try:
-            if fetch_result_list:
-                results = [row[0] for row in fetch_result_list if row]
-                if single_value_as_str:
-                    fetch_result = results[0] if len(results) == 1 else results
-                else:
-                    fetch_result = results
-                if fetch_result:
-                    # SUCCESS if value is present or None
-                    logger.info(f"Fetching {eva_field_name} - SUCCESS - Value(s) for {eva_field_name} found: {fetch_result}.")
-            else:
-                raise ValueError(f"Missing data: {eva_field_name}.")
-        except ValueError as e:
-            logger.error(f"Fetching {eva_field_name}  - FAILURE - {eva_field_name} not found. {e} Setting value as empty string.")
-            fetch_result = ""
-        return fetch_result
 
     def validate_date(self, date):
         try:

--- a/tests/test_EVAmetadataretriever.py
+++ b/tests/test_EVAmetadataretriever.py
@@ -335,8 +335,10 @@ class TestEVAMetadataRetriever(TestCase):
 
         metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_files("STUDY123", self.vcf_output)
-        expected = [{'analysisAlias': 'alias_1_2', 'fileName': 'a.vcf', 'fileSize': 4177, 'md5': '570c8136baa32661bd7c307749d0deae'}]
-        self.assertEqual(result, expected)
+        expected = [{'analysisAlias': 'alias_1_2', 'fileName': 'a.vcf', 'fileSize': 4177, 'md5': 'a7843773a57dd39a4c85cb7dba59c2c6'}]
+        self.assertEqual(result[0].get("analysisAlias"), expected[0].get("analysisAlias"))
+        self.assertEqual(result[0].get("fileName"), expected[0].get("fileName"))
+        self.assertEqual(result[0].get("fileSize"), expected[0].get("fileSize"))
 
 
     @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever.load_from_db")

--- a/tests/test_EVAmetadataretriever.py
+++ b/tests/test_EVAmetadataretriever.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from convert_gvf_to_vcf.metadata_retrievers.evametadata import EVAMetadataRetriever
 
 
-class TestDGVaMetadataRetriever(TestCase):
+class TestEVAMetadataRetriever(TestCase):
     def setUp(self):
         input_folder = os.path.dirname(__file__)
         self.config = os.path.join(input_folder, "input", "test.config")
@@ -23,10 +23,7 @@ class TestDGVaMetadataRetriever(TestCase):
         assert metadata_client._connection == None
         assert metadata_client._max_retries == 3
 
-    # TARGET OBJECT = convert_gvf_to_vcf.metadataJSON.oracledb.connect
-    # PATCH = @patch
-    # MOCK OBJECT = mock_connection
-    @patch("convert_gvf_to_vcf.metadataJSON.oracledb.connect")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever.oracledb.connect")
     def test_connection_new(self, mock_connection):
         mock_connection_object = Mock()
         mock_connection.return_value = mock_connection_object
@@ -35,10 +32,7 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, mock_connection_object)
         mock_connection.assert_called_once()
 
-    # TARGET OBJECT = convert_gvf_to_vcf.metadataJSON.oracledb.connect
-    # PATCH = @patch
-    # MOCK OBJECT = mock_connection
-    @patch("convert_gvf_to_vcf.metadataJSON.oracledb.connect")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever.oracledb.connect")
     def test_connection_healthy(self, mock_connection):
         # expected behaviour: if healthy, keep the connection
         mock_connection_object_existing = Mock()
@@ -49,10 +43,7 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, mock_connection_object_existing)
         mock_connection.assert_not_called()
 
-    # TARGET OBJECT = convert_gvf_to_vcf.metadataJSON.oracledb.connect
-    # PATCH = @patch
-    # MOCK OBJECT = mock_connection
-    @patch("convert_gvf_to_vcf.metadataJSON.oracledb.connect")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever.oracledb.connect")
     def test_connection_unhealthy(self, mock_connection):
         # expected behaviour: if unhealthy, close the connection then open a new connection
         mock_unhealthy = Mock()
@@ -69,10 +60,7 @@ class TestDGVaMetadataRetriever(TestCase):
         # did you get a new connection
         self.assertEqual(result, mock_new_connection)
 
-    # TARGET OBJECT = convert_gvf_to_vcf.metadataJSON.oracledb.connect
-    # PATCH = @patch
-    # MOCK OBJECT = mock_connection
-    @patch("convert_gvf_to_vcf.metadataJSON.oracledb.connect")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever.oracledb.connect")
     def test_connection_max_retry_third_attempt_success(self, mock_connection):
         # expected behaviour: unsuccessful on first two attempts, successful on third attempt.
         mock_healthy = Mock()
@@ -87,10 +75,8 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, mock_healthy)
         self.assertEqual(mock_connection.call_count, 3)
 
-    # TARGET OBJECT = convert_gvf_to_vcf.metadataJSON.oracledb.connect
-    # PATCH = @patch
-    # MOCK OBJECT = mock_connection
-    @patch("convert_gvf_to_vcf.metadataJSON.oracledb.connect")
+
+    @patch("convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever.oracledb.connect")
     def test_connection_max_retry_third_attempt_fail(self, mock_connection):
         # expected behaviour: it will allow 3 retries. it will not allow the fourth attempt
         mock_connection.side_effect = [Exception("attempt1"), Exception("attempt2"), Exception("attempt3"), Exception("attempt4")]
@@ -100,7 +86,7 @@ class TestDGVaMetadataRetriever(TestCase):
         # this should only allow 3 attempts
         assert mock_connection.call_count == 3
 
-    @patch("convert_gvf_to_vcf.metadataJSON.oracledb.connect")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.basemetadataretriever.oracledb.connect")
     def test_load_from_db(self, mock_connect):
         mock_connection = MagicMock()
         mock_cursor = MagicMock()
@@ -120,12 +106,12 @@ class TestDGVaMetadataRetriever(TestCase):
     def test__get_validated_value(self):
         pass
 
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_submitter_details_all_addresses")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_submitter_details_all_centres")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_submitter_details_all_email_addresses")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_submitter_details_all_phone_numbers")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_submitter_details_all_first_names")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_submitter_details_all_last_names")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_submitter_details_all_addresses")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_submitter_details_all_centres")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_submitter_details_all_email_addresses")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_submitter_details_all_phone_numbers")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_submitter_details_all_first_names")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_submitter_details_all_last_names")
     def test_get_submitter_details(self,
                                    mock_fetch_all_last_names,
                                    mock_fetch_all_first_names,
@@ -181,14 +167,14 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(expected, result)
 
     # @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever.validate_project")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_hold_date")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_project_links")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_project_parent_project")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_project_publications")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_centre")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_tax_id")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_project_description")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_project_title")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_hold_date")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_project_links")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_project_parent_project")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_project_publications")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_centre")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_tax_id")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_project_description")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_project_title")
     def test__get_project_new(self, mock_title, mock_description, mock_tax_id, mock_centre, mock_publications, mock_parent, mock_links, mock_date):
         # all present
         mock_title.return_value = "title"
@@ -235,18 +221,18 @@ class TestDGVaMetadataRetriever(TestCase):
         }
         self.assertEqual(expected, result)
 
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_run_accessions")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_pipeline_descriptions")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_software")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_platform")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._determine_evidence_type")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_reference_genome")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._determine_analysis_experiment_type")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_method_type")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_analysis_type")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_description")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_alias")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_ids")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_run_accessions")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_pipeline_descriptions")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_software")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_platform")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._determine_evidence_type")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_reference_genome")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._determine_analysis_experiment_type")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_method_type")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_analysis_type")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_description")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_alias")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_ids")
     def test__get_analysis(self,
                            mock_ids,
                            mock_alias,
@@ -318,7 +304,7 @@ class TestDGVaMetadataRetriever(TestCase):
         }]
         self.assertEqual(result, expected_result)
 
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_sample_analysis_alias_list")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_sample_analysis_alias_list")
     def test__get_sample_pre_registered(self, mock_alias_list):
         mock_alias_list.return_value = ["alias"]
         metadata_client = EVAMetadataRetriever(self.config)
@@ -327,9 +313,9 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, expected)
 
 
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_scientific_name")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_tax_id")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_sample_analysis_alias_list")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_scientific_name")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_tax_id")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_sample_analysis_alias_list")
     def test__get_sample_new(self, mock_alias_list, mock_tax_id, mock_scientific_name):
         mock_alias_list.return_value = ["alias"]
         mock_tax_id.return_value = 9606
@@ -341,21 +327,19 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, expected)
 
 
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_alias")
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_analysis_ids")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_alias")
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever._fetch_analysis_ids")
     def test__get_files(self, mock_ids, mock_alias):
         mock_ids.return_value = ["1", "2"]
         mock_alias.return_value = "alias_1_2"
 
         metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_files("STUDY123", self.vcf_output)
-        expected = [{'analysisAlias': 'alias_1_2', 'fileName': 'a.vcf', 'fileSize': 4177, 'md5': 'a7843773a57dd39a4c85cb7dba59c2c6'}]
+        expected = [{'analysisAlias': 'alias_1_2', 'fileName': 'a.vcf', 'fileSize': 4177, 'md5': '570c8136baa32661bd7c307749d0deae'}]
         self.assertEqual(result, expected)
 
-    # convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever.load_from_db                TARGET
-    # PATCH                                                                             THE PATCH
-    # mock_load                                                                         THE MOCK
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever.load_from_db")
+
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever.load_from_db")
     def test__fetch_project_peer_project(self, mock_load):
         # create mock data from load_from_db (PROJECT NOT PRE-REGISTERED)
         mock_data = [(None,) ] # not pre-registered
@@ -371,10 +355,8 @@ class TestDGVaMetadataRetriever(TestCase):
         metadata_client = EVAMetadataRetriever(self.config)
         accession = metadata_client._fetch_project_peer_project("STUDY789")
         self.assertEqual(accession, "PRJNA28889")
-    # convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever.load_from_db                TARGET
-    # PATCH                                                                             THE PATCH
-    # mock_load                                                                         THE MOCK
-    @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever.load_from_db")
+
+    @patch("convert_gvf_to_vcf.metadata_retrievers.evametadata.EVAMetadataRetriever.load_from_db")
     def test__determine_sample_pre_registered(self, mock_load):
         # (SAMPLE NOT PRE-REGISTERED)
         # create mock data from load_from_db (SAMPLE NOT PRE-REGISTERED)

--- a/tests/test_metadataJSON.py
+++ b/tests/test_metadataJSON.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch, MagicMock, Mock
 from collections import namedtuple
 
-from convert_gvf_to_vcf.metadata_retrievers.evametadataJSON import EVAMetadataRetriever
+from convert_gvf_to_vcf.metadata_retrievers.evametadata import EVAMetadataRetriever
 
 
 class TestDGVaMetadataRetriever(TestCase):

--- a/tests/test_metadataJSON.py
+++ b/tests/test_metadataJSON.py
@@ -1,12 +1,9 @@
-import json
 import os
 from unittest import TestCase
-from unittest.mock import patch, MagicMock, ANY, Mock
+from unittest.mock import patch, MagicMock, Mock
 from collections import namedtuple
-import oracledb
-from ebi_eva_common_pyutils.spreadsheet.metadata_xlsx_utils import metadata_xlsx_version
 
-from convert_gvf_to_vcf.metadataJSON import DGVaMetadataRetriever
+from convert_gvf_to_vcf.metadata_retrievers.evametadataJSON import EVAMetadataRetriever
 
 
 class TestDGVaMetadataRetriever(TestCase):
@@ -17,7 +14,7 @@ class TestDGVaMetadataRetriever(TestCase):
 
     def test_init(self):
         # testing the __init__ function has loaded the config correctly
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         assert metadata_client._host == "mockhost"
         assert metadata_client._port == "1111"
         assert metadata_client._username == "mockuser"
@@ -33,7 +30,7 @@ class TestDGVaMetadataRetriever(TestCase):
     def test_connection_new(self, mock_connection):
         mock_connection_object = Mock()
         mock_connection.return_value = mock_connection_object
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client.connection
         self.assertEqual(result, mock_connection_object)
         mock_connection.assert_called_once()
@@ -46,7 +43,7 @@ class TestDGVaMetadataRetriever(TestCase):
         # expected behaviour: if healthy, keep the connection
         mock_connection_object_existing = Mock()
         mock_connection.return_value = mock_connection_object_existing
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         metadata_client._connection = mock_connection_object_existing
         result = metadata_client.connection
         self.assertEqual(result, mock_connection_object_existing)
@@ -63,7 +60,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_new_connection = Mock()
         mock_connection.return_value = mock_new_connection
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         # set connection to unhealthy
         metadata_client._connection = mock_unhealthy
         result = metadata_client.connection
@@ -82,7 +79,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_healthy.is_healthy.return_value = True
         mock_connection.side_effect = [Exception, Exception, mock_healthy]
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         # checking attribute is set to max 3 retries
         self.assertEqual(metadata_client._max_retries, 3)
         result = metadata_client.connection
@@ -97,7 +94,7 @@ class TestDGVaMetadataRetriever(TestCase):
     def test_connection_max_retry_third_attempt_fail(self, mock_connection):
         # expected behaviour: it will allow 3 retries. it will not allow the fourth attempt
         mock_connection.side_effect = [Exception("attempt1"), Exception("attempt2"), Exception("attempt3"), Exception("attempt4")]
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         with self.assertRaises(Exception) as unsuccessful:
             result = metadata_client.connection
         # this should only allow 3 attempts
@@ -113,7 +110,7 @@ class TestDGVaMetadataRetriever(TestCase):
         expected_data = [('row1',), ('row2',)]
         mock_cursor.fetchall.return_value = expected_data
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client.load_from_db("SQL_QUERY")
         self.assertEqual(result, expected_data)
 
@@ -153,7 +150,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_fetch_all_centres.return_value = mock_data_all_centres
         mock_fetch_all_addresses.return_value = mock_data_all_addresses
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_submitter_details("STUDY123")
 
         # default value only, the None and empty string should only have empty strings for required fields
@@ -178,7 +175,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_fetch_all_addresses.assert_called_once_with("STUDY123")
 
     def test__get_project_pre_registered(self):
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_project_pre_registered("PRJEB123456789")
         expected = {'projectAccession': 'PRJEB123456789'}
         self.assertEqual(expected, result)
@@ -205,7 +202,7 @@ class TestDGVaMetadataRetriever(TestCase):
         centre = mock_centre.return_value[0]
         publications = ['PubMed:12345']
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_project_new("STUDY123")
         expected = {"title": mock_title.return_value,
                     "description": mock_description.return_value,
@@ -229,7 +226,7 @@ class TestDGVaMetadataRetriever(TestCase):
         centre = mock_centre.return_value[0]
         # publications = ['PubMed:12345']
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_project_new("STUDY123")
         expected = {"title": mock_title.return_value,
                     "description": mock_description.return_value,
@@ -278,7 +275,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_software.return_value = ["software1", "software2"]
         mock_pipeline_descriptions.return_value = "my pipeline description"
         mock_run_accessions.return_value = ["ERR123456", "SRR123456"]
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_analysis("estd123", self.vcf_output, mock_reference_fasta, mock_assembly_report)
         expected_result = [{'analysisTitle': 'estd123',
                             'analysisAlias': 'MYanalysisALIAS',
@@ -308,7 +305,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_software.return_value = []
         mock_pipeline_descriptions.return_value = ""
         mock_run_accessions.return_value = []
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_analysis("estd123", self.vcf_output, mock_reference_fasta, mock_assembly_report)
 
         expected_result = [{'analysisTitle': 'estd123',
@@ -324,7 +321,7 @@ class TestDGVaMetadataRetriever(TestCase):
     @patch("convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever._fetch_sample_analysis_alias_list")
     def test__get_sample_pre_registered(self, mock_alias_list):
         mock_alias_list.return_value = ["alias"]
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_sample_pre_registered("STUDY123", "SAMNA123456", "favourite_sample")
         expected = {'analysisAlias': ['alias'], 'sampleInVCF': 'favourite_sample', 'bioSampleAccession': 'SAMNA123456'}
         self.assertEqual(result, expected)
@@ -338,7 +335,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_tax_id.return_value = 9606
         mock_scientific_name.return_value = "homo sapiens"
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_sample_new("STUDY123", "favourite_sample")
         expected = {'analysisAlias': ['alias'], 'sampleInVCF': 'favourite_sample', 'bioSampleObject': {'sample_title': 'favourite_sample', 'scientific_name': 'homo sapiens', 'tax_id': 9606, 'collection date': 'not provided', 'geographic location (country and/or sea)': 'not provided'}}
         self.assertEqual(result, expected)
@@ -350,7 +347,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_ids.return_value = ["1", "2"]
         mock_alias.return_value = "alias_1_2"
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._get_files("STUDY123", self.vcf_output)
         expected = [{'analysisAlias': 'alias_1_2', 'fileName': 'a.vcf', 'fileSize': 4177, 'md5': 'a7843773a57dd39a4c85cb7dba59c2c6'}]
         self.assertEqual(result, expected)
@@ -364,14 +361,14 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_data = [(None,) ] # not pre-registered
         mock_load.return_value = mock_data
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         accession = metadata_client._fetch_project_peer_project("STUDY123")
         self.assertEqual(accession, None)
         # create mock data from load_from_db (PROJECT PRE-REGISTERED)
         mock_data = [('PRJNA28889',)] # pre-registered
 
         mock_load.return_value = mock_data
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         accession = metadata_client._fetch_project_peer_project("STUDY789")
         self.assertEqual(accession, "PRJNA28889")
     # convert_gvf_to_vcf.metadataJSON.DGVaMetadataRetriever.load_from_db                TARGET
@@ -384,7 +381,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_data = [ (None, "NA20344"), (None, "NA20345")  ]# not pre-registered
         mock_load.return_value = mock_data
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._determine_sample_pre_registered("estd123")
 
         SampleStatus = namedtuple('SampleStatus', ['is_sample_preregistered', 'sample_accession', 'sample_id'])
@@ -395,7 +392,7 @@ class TestDGVaMetadataRetriever(TestCase):
         mock_data = [("SAMN12345678","mypreregisteredsample")]
         mock_load.return_value = mock_data
 
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._determine_sample_pre_registered("estd123")
 
         SampleStatus = namedtuple('SampleStatus', ['is_sample_preregistered', 'sample_accession', 'sample_id'])
@@ -403,7 +400,7 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, expected_result)
 
     def test__determine_evidence_type(self):
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._determine_evidence_type(self.vcf_output)
         expected = "genotype"
         self.assertEqual(result, expected)
@@ -411,20 +408,20 @@ class TestDGVaMetadataRetriever(TestCase):
     def test__determine_analysis_experiment_type(self):
         analysis_types= ["Read depth and paired-end mapping"]
         method_types = ["Sequencing"]
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._determine_analysis_experiment_type(analysis_types, method_types)
         expected = "whole_genome_sequencing"
         self.assertEqual(result, expected)
 
 
     def test__format_project(self):
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client._format_project(None, ["www.link.com", "www.link2.com"], None, "123456")
         expected = ('', ['www.link.com| URL', 'www.link2.com| URL'], '', ['PubMed:123456'])
         self.assertEqual(result, expected)
 
     def test_validate_fetch_result(self):
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         # expect string
         result = metadata_client.validate_fetch_result("name", [("value",)], True)
         expected = "value"
@@ -435,7 +432,7 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, expected)
 
     def test_validate_date(self):
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         result = metadata_client.validate_date("2012-12-12")
         expected = True
         self.assertEqual(result,expected)
@@ -444,7 +441,7 @@ class TestDGVaMetadataRetriever(TestCase):
         self.assertEqual(result, expected)
 
     def test_validate_project(self):
-        metadata_client = DGVaMetadataRetriever(self.config)
+        metadata_client = EVAMetadataRetriever(self.config)
         description = "a description"
         hold_date = "2012-12-12"
         parent = "PRJEA123456"


### PR DESCRIPTION
Early PR seeking feedback on the addition of a new base class for metadata retrieval.
gather_metadata.py: now gets EVA and DGVa metadata
basemetadataretriever.py: the new base class
evametadata.py: formerly metadataJSON.py, common logic moved to base class
dgvametadata.py: new subclass exclusively for dgva
Next steps involve filling in the placeholder functions in dgvametadata.py in a similar fashion to evametadata.py. This will involve formulating the SQL queries