### PR TITLE
refactor: fix parsing of gvf file

### DIFF
--- a/convert_gvf_to_vcf/gvf_metadata_coordinator.py
+++ b/convert_gvf_to_vcf/gvf_metadata_coordinator.py
@@ -253,13 +253,15 @@ class GvfMetadataCoordinator:
             return None, None, None
         # expect file_name = {estd1_Redon_et_al_2006}.{YYYY-MM-DD}.{Assembly}.{Submitted/Remapped}.gvf
         file_name = os.path.basename(gvf_file)
-        if not (file_name.endswith(".Submitted.gvf") or file_name.endswith(".Remapped.gvf")):
+        valid_gvf_endings = (".Submitted.gvf", ".Remapped.gvf",".Submitted.gvf.sorted.gvf", ".Remapped.gvf.sorted.gvf")
+        if not file_name.endswith(valid_gvf_endings):
             logger.warning(f"Warning: Skipping invalid GVF file name structure: {file_name}")
             return None, None, None
         # expect base_name = ['estd1_Redon_et_al_2006.2014-04-01.GRCh37', 'Remapped', 'gvf']
-        base_name = file_name.rsplit(".", 2)
-        # expect base_name[0] = {estd1_Redon_et_al_2006}.{YYYY-MM-DD}.{Assembly}
-        parts = base_name[0].split(".", 2) # maxsplit 2 to handle patched assemblies i.e. assembly can be GRCh37 or GRCh37.p13
+        file_ending = next((ext for ext in valid_gvf_endings if file_name.endswith(ext)), None)
+        base_name = file_name[:-len(file_ending)]
+        # expect base_name = {estd1_Redon_et_al_2006}.{YYYY-MM-DD}.{Assembly}
+        parts = base_name.split(".", 2) # maxsplit 2 to handle patched assemblies i.e. assembly can be GRCh37 or GRCh37.p13
         if len(parts) < 3:
             logger.warning(f"Warning: Skipping invalid GVF file name structure: {file_name}")
             return None, None, None

--- a/tests/test_gvf_metadata_coordinator.py
+++ b/tests/test_gvf_metadata_coordinator.py
@@ -265,11 +265,20 @@ class TestGvfMetadataCoordinator(unittest.TestCase):
         date = "2014-04-01"
         gvf_files = [f"{study_name}.{date}.GRCh37.Remapped.gvf",
                      f"{study_name}.{date}.GRCh38.Remapped.gvf",
-                     f"{study_name}.{date}.GRCh37.Submitted.gvf"
+                     f"{study_name}.{date}.GRCh37.Submitted.gvf",
+                     f"{study_name}.{date}.GRCh37.Submitted.gvf.sorted.gvf",
+                     f"{study_name}.{date}.GRCh37.p13.Submitted.gvf",
+                     f"{study_name}.{date}.GRCh37.p13.Submitted.gvf.sorted.gvf",
+                     f"{study_name}.{date}.GRCh37.ABCDEFG.txt", # invalid
+
         ]
         study_1, date_1, assembly_1 = coordinator.parse_gvf_filename(gvf_files[0])
         study_2, date_2, assembly_2 = coordinator.parse_gvf_filename(gvf_files[1])
         study_3, date_3, assembly_3 = coordinator.parse_gvf_filename(gvf_files[2])
+        study_4, date_4, assembly_4 = coordinator.parse_gvf_filename(gvf_files[3])
+        study_5, date_5, assembly_5 = coordinator.parse_gvf_filename(gvf_files[4])
+        study_6, date_6, assembly_6 = coordinator.parse_gvf_filename(gvf_files[5])
+        study_7, date_7, assembly_7 = coordinator.parse_gvf_filename(gvf_files[6])
 
         self.assertEqual(study_1, study_name)
         self.assertEqual(date_1, date)
@@ -282,6 +291,22 @@ class TestGvfMetadataCoordinator(unittest.TestCase):
         self.assertEqual(study_3, study_name)
         self.assertEqual(date_3, date)
         self.assertEqual(assembly_3, "GRCh37")
+
+        self.assertEqual(study_4, study_name)
+        self.assertEqual(date_4, date)
+        self.assertEqual(assembly_4, "GRCh37")
+
+        self.assertEqual(study_5, study_name)
+        self.assertEqual(date_5, date)
+        self.assertEqual(assembly_5, "GRCh37.p13")
+
+        self.assertEqual(study_6, study_name)
+        self.assertEqual(date_6, date)
+        self.assertEqual(assembly_6, "GRCh37.p13")
+
+        self.assertEqual(study_7, None)
+        self.assertEqual(date_7, None)
+        self.assertEqual(assembly_7, None)
 
     def test_add_multiple_assemblies_into_metadata(self):
         coordinator = GvfMetadataCoordinator(MagicMock(), MagicMock(), MagicMock())


### PR DESCRIPTION
This PR fixes the parsing of GVF files to obtain the assembly (commit https://github.com/EBIvariation/convertGVFtoVCF/commit/361cb0ff462ff99be25926ae3f6562e78ca8170b).
The main changes for this fix lie in:
gvf_metadata_coordinator.py - added sorted.gvf to valid file endings for accurate parsing
test_gvf_metadata_coordinator.py - added test